### PR TITLE
Handle null cases of response headers in ApiException

### DIFF
--- a/src/main/java/com/launchdarkly/api/ApiException.java
+++ b/src/main/java/com/launchdarkly/api/ApiException.java
@@ -160,7 +160,8 @@ public class ApiException extends Exception {
      * @return The exception message
      */
     public String getMessage() {
+        final String headers = getResponseHeaders() == null ? "" : this.getResponseHeaders().toString();
         return String.format("Message: %s%nHTTP response code: %s%nHTTP response body: %s%nHTTP response headers: %s",
-                super.getMessage(), this.getCode(), this.getResponseBody(), this.getResponseHeaders().toString());
+                super.getMessage(), this.getCode(), this.getResponseBody(), headers);
     }
 }


### PR DESCRIPTION
Handling null pointer exception mentioned in https://github.com/launchdarkly/api-client-java/issues/16